### PR TITLE
Add asset and eth rate historical data

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -113,6 +113,10 @@ type Currency @entity {
   cashGroup: CashGroup @derivedFrom(field: "currency")
   "nToken for a currency, if exists"
   nToken: nToken @derivedFrom(field: "currency")
+
+  "Hourly data for this currency"
+  ethExchangeRateHistoricalData: [EthExchangeRateHistoricalData!]
+  assetExchangeRateHistoricalData: [AssetExchangeRateHistoricalData!]
 }
 
 type EthExchangeRate @entity {
@@ -520,6 +524,20 @@ type nTokenChange @entity {
   integralTotalSupplyAfter: BigInt!
   lastSupplyChangeTimeBefore: BigInt!
   lastSupplyChangeTimeAfter: BigInt!
+}
+
+type EthExchangeRateHistoricalData @entity {
+  id: ID!
+  timestamp: Int!
+  value: BigInt!
+  ethExchangeRate: EthExchangeRate!
+}
+
+type AssetExchangeRateHistoricalData @entity {
+  id: ID!
+  timestamp: Int!
+  value: BigInt!
+  assetExchangeRate: AssetExchangeRate!
 }
 
 type AssetTransfer @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -117,6 +117,7 @@ type Currency @entity {
   "Hourly data for this currency"
   ethExchangeRateHistoricalData: [EthExchangeRateHistoricalData!]
   assetExchangeRateHistoricalData: [AssetExchangeRateHistoricalData!]
+  nTokenPresentValueHistoricalData: [NTokenPresentValueHistoricalData!]
 }
 
 type EthExchangeRate @entity {
@@ -530,14 +531,22 @@ type EthExchangeRateHistoricalData @entity {
   id: ID!
   timestamp: Int!
   value: BigInt!
-  ethExchangeRate: EthExchangeRate!
+  currency: Currency!
 }
 
 type AssetExchangeRateHistoricalData @entity {
   id: ID!
   timestamp: Int!
   value: BigInt!
-  assetExchangeRate: AssetExchangeRate!
+  currency: Currency!
+}
+
+type NTokenPresentValueHistoricalData @entity {
+  id: ID!
+  timestamp: Int!
+  pvAsset: BigInt!
+  pvUnderlying: BigInt!
+  currency: Currency!
 }
 
 type AssetTransfer @entity {

--- a/src/exchange_rates/utils.ts
+++ b/src/exchange_rates/utils.ts
@@ -1,0 +1,38 @@
+import {
+    AssetExchangeRate,
+    AssetExchangeRateHistoricalData,
+    EthExchangeRate,
+    EthExchangeRateHistoricalData
+} from '../../generated/schema';
+
+export function getEthExchangeRate(id: string): EthExchangeRate {
+    let entity = EthExchangeRate.load(id);
+    if (entity == null) {
+      entity = new EthExchangeRate(id);
+    }
+    return entity as EthExchangeRate;
+}
+
+export function getAssetExchangeRate(id: string): AssetExchangeRate {
+    let entity = AssetExchangeRate.load(id);
+    if (entity == null) {
+      entity = new AssetExchangeRate(id);
+    }
+    return entity as AssetExchangeRate;
+}
+
+export function getEthExchangeRateHistoricalData(id: string): EthExchangeRateHistoricalData {
+    let entity = EthExchangeRateHistoricalData.load(id);
+    if (entity == null) {
+        entity = new EthExchangeRateHistoricalData(id);
+    }
+    return entity as EthExchangeRateHistoricalData;
+}
+
+export function getAssetExchangeRateHistoricalData(id: string): AssetExchangeRateHistoricalData {
+    let entity = AssetExchangeRateHistoricalData.load(id);
+    if (entity == null) {
+        entity = new AssetExchangeRateHistoricalData(id);
+    }
+    return entity as AssetExchangeRateHistoricalData;
+}

--- a/src/notional.ts
+++ b/src/notional.ts
@@ -33,8 +33,6 @@ import {updateDailyLendBorrowVolume} from './utils/intervalUpdates'
 
 import {
   Currency,
-  EthExchangeRate,
-  AssetExchangeRate,
   CashGroup,
   nToken,
   GlobalTransferOperator,
@@ -45,6 +43,17 @@ import {
   AuthorizedCallbackContract,
 } from '../generated/schema';
 import {BASIS_POINTS, getMarketIndex, getMarketMaturityLengthSeconds, getSettlementDate, getTimeRef, getTrade, QUARTER} from './common';
+
+import {
+  getEthExchangeRate,
+  getAssetExchangeRate
+} from './exchange_rates/utils'
+
+import {
+  updateAssetExchangeRateHistoricalData,
+  updateEthExchangeRateHistoricalData
+} from './timeseriesUpdate'
+
 import {updateMarkets} from './markets';
 import {convertAssetToUnderlying, getBalance, updateAccount, updateNTokenPortfolio} from './accounts';
 
@@ -59,22 +68,6 @@ function getCurrency(id: string): Currency {
     entity = new Currency(id);
   }
   return entity as Currency;
-}
-
-function getEthExchangeRate(id: string): EthExchangeRate {
-  let entity = EthExchangeRate.load(id);
-  if (entity == null) {
-    entity = new EthExchangeRate(id);
-  }
-  return entity as EthExchangeRate;
-}
-
-function getAssetExchangeRate(id: string): AssetExchangeRate {
-  let entity = AssetExchangeRate.load(id);
-  if (entity == null) {
-    entity = new AssetExchangeRate(id);
-  }
-  return entity as AssetExchangeRate;
 }
 
 export function getCashGroup(id: string): CashGroup {
@@ -226,6 +219,8 @@ export function handleUpdateETHRate(event: UpdateETHRate): void {
 
   log.debug('Updated ethExchangeRate variables for entity {}', [ethExchangeRate.id]);
   ethExchangeRate.save();
+
+  updateEthExchangeRateHistoricalData(ethExchangeRate, event);
 }
 
 export function handleUpdateAssetRate(event: UpdateAssetRate): void {
@@ -246,6 +241,8 @@ export function handleUpdateAssetRate(event: UpdateAssetRate): void {
 
   log.debug('Updated assetExchangeRate variables for entity {}', [assetExchangeRate.id]);
   assetExchangeRate.save();
+
+  updateAssetExchangeRateHistoricalData(assetExchangeRate, event);
 }
 
 export function handleUpdateCashGroup(event: UpdateCashGroup): void {

--- a/src/timeseriesUpdate.ts
+++ b/src/timeseriesUpdate.ts
@@ -1,15 +1,12 @@
-import {Address, BigInt, log} from '@graphprotocol/graph-ts';
-import { Notional, UpdateAssetRate, UpdateETHRate } from '../generated/Notional/Notional';
+import { log } from '@graphprotocol/graph-ts';
+import { Notional } from '../generated/Notional/Notional';
 
 import { 
-    AssetExchangeRate,
-    EthExchangeRate
-} from '../generated/schema';
-
-import { 
-    getAssetExchangeRateHistoricalData,
-    getEthExchangeRateHistoricalData
+  getAssetExchangeRateHistoricalData,
+  getEthExchangeRateHistoricalData
 } from './exchange_rates/utils'
+
+import { getNTokenPresentValueHistoricalData } from './notional';
 
 /* 
     Historical data is stored on an hourly basis to keep it lean, this could be changed in the future
@@ -17,44 +14,60 @@ import {
 */
 
 function createHourlyId(currencyId: number, timestamp: i32): string {
-    let uniqueHourIndex = timestamp / 3600; // Integer division will always floor result
+  let uniqueHourIndex = timestamp / 3600; // Integer division will always floor result
 
-    return currencyId
-        .toString()
-        .concat(':')
-        .concat(uniqueHourIndex.toString());
+  return currencyId
+    .toString()
+    .concat(':')
+    .concat(uniqueHourIndex.toString());
 }
 
-export function updateEthExchangeRateHistoricalData(ethExchangeRate: EthExchangeRate, event: UpdateETHRate): void {
-    let historicalId = createHourlyId(event.params.currencyId, event.block.timestamp.toI32());
-    let ethExchangeRateHistoricalData = getEthExchangeRateHistoricalData(historicalId);
-    let roundedTimestamp = (event.block.timestamp.toI32() / 3600) * 3600;
+export function updateEthExchangeRateHistoricalData(notional: Notional, currencyId: i32, timestamp: i32): void {
+  let historicalId = createHourlyId(currencyId, timestamp);
+  let ethExchangeRateHistoricalData = getEthExchangeRateHistoricalData(historicalId);
+  let roundedTimestamp = (timestamp / 3600) * 3600;
 
-    let notional = Notional.bind(event.address);
-    let rateResult = notional.getCurrencyAndRates(event.params.currencyId);
-    let ethRate = rateResult.value2;
+  let result = notional.getCurrencyAndRates(currencyId);
+  let ethRate = result.value2;
 
-    ethExchangeRateHistoricalData.timestamp = roundedTimestamp;
-    ethExchangeRateHistoricalData.value = ethRate.rate.div(BigInt.fromI32(10).pow(10));
-    ethExchangeRateHistoricalData.ethExchangeRate = ethExchangeRate.id;
+  ethExchangeRateHistoricalData.timestamp = roundedTimestamp;
+  ethExchangeRateHistoricalData.value = ethRate.rate;
+  ethExchangeRateHistoricalData.currency = currencyId.toString();
 
-    log.debug('Updated ethExchangeRateHistoricalData variables for entity {}', [ethExchangeRateHistoricalData.id]);
-    ethExchangeRateHistoricalData.save();
+  log.debug('Updated ethExchangeRateHistoricalData variables for entity {}', [ethExchangeRateHistoricalData.id]);
+  ethExchangeRateHistoricalData.save();
 }
 
-export function updateAssetExchangeRateHistoricalData(assetExchangeRate: AssetExchangeRate, event: UpdateAssetRate): void {
-    let historicalId = createHourlyId(event.params.currencyId, event.block.timestamp.toI32());
-    let assetExchangeRateHistoricalData = getAssetExchangeRateHistoricalData(historicalId);
-    let roundedTimestamp = (event.block.timestamp.toI32() / 3600) * 3600;
+export function updateAssetExchangeRateHistoricalData(notional: Notional, currencyId: i32, timestamp: i32): void {
+  let historicalId = createHourlyId(currencyId, timestamp);
+  let assetExchangeRateHistoricalData = getAssetExchangeRateHistoricalData(historicalId);
+  let roundedTimestamp = (timestamp / 3600) * 3600;
 
-    let notional = Notional.bind(event.address);
-    let rateResult = notional.getCurrencyAndRates(event.params.currencyId);
-    let assetRate = rateResult.value3;
+  let result = notional.getCurrencyAndRates(currencyId);
+  let assetRate = result.value3;
 
-    assetExchangeRateHistoricalData.timestamp = roundedTimestamp;
-    assetExchangeRateHistoricalData.value = assetRate.rate.div(BigInt.fromI32(10).pow(10));
-    assetExchangeRateHistoricalData.assetExchangeRate = assetExchangeRate.id;
+  assetExchangeRateHistoricalData.timestamp = roundedTimestamp;
+  assetExchangeRateHistoricalData.value = assetRate.rate;
+  assetExchangeRateHistoricalData.currency = currencyId.toString();
 
-    log.debug('Updated assetExchangeRateHistoricalData variables for entity {}', [assetExchangeRateHistoricalData.id]);
-    assetExchangeRateHistoricalData.save();
+  log.debug('Updated assetExchangeRateHistoricalData variables for entity {}', [assetExchangeRateHistoricalData.id]);
+  assetExchangeRateHistoricalData.save();
+}
+
+export function updateNTokenPresentValueHistoricalData(notional: Notional, currencyId: i32, timestamp: i32): void {
+  let pvAsset = notional.try_nTokenPresentValueAssetDenominated(currencyId)
+  let pvUnderlying = notional.try_nTokenPresentValueUnderlyingDenominated(currencyId)
+  if (pvAsset.reverted || pvUnderlying.reverted) return;
+  
+  let historicalId = createHourlyId(currencyId, timestamp);
+  let nTokenPresentValueHistoricalData = getNTokenPresentValueHistoricalData(historicalId);
+  let roundedTimestamp = (timestamp / 3600) * 3600;
+
+  nTokenPresentValueHistoricalData.timestamp = roundedTimestamp;
+  nTokenPresentValueHistoricalData.pvAsset = pvAsset.value;
+  nTokenPresentValueHistoricalData.pvUnderlying = pvUnderlying.value;
+  nTokenPresentValueHistoricalData.currency = currencyId.toString();
+
+  log.debug('Updated nTokenPresentValueHistoricalData variables for entity {}', [nTokenPresentValueHistoricalData.id]);
+  nTokenPresentValueHistoricalData.save();
 }

--- a/src/timeseriesUpdate.ts
+++ b/src/timeseriesUpdate.ts
@@ -1,0 +1,60 @@
+import {Address, BigInt, log} from '@graphprotocol/graph-ts';
+import { Notional, UpdateAssetRate, UpdateETHRate } from '../generated/Notional/Notional';
+
+import { 
+    AssetExchangeRate,
+    EthExchangeRate
+} from '../generated/schema';
+
+import { 
+    getAssetExchangeRateHistoricalData,
+    getEthExchangeRateHistoricalData
+} from './exchange_rates/utils'
+
+/* 
+    Historical data is stored on an hourly basis to keep it lean, this could be changed in the future
+    or be kept as multiple time periods. New values during the timespan updates the hourly value
+*/
+
+function createHourlyId(currencyId: number, timestamp: i32): string {
+    let uniqueHourIndex = timestamp / 3600; // Integer division will always floor result
+
+    return currencyId
+        .toString()
+        .concat(':')
+        .concat(uniqueHourIndex.toString());
+}
+
+export function updateEthExchangeRateHistoricalData(ethExchangeRate: EthExchangeRate, event: UpdateETHRate): void {
+    let historicalId = createHourlyId(event.params.currencyId, event.block.timestamp.toI32());
+    let ethExchangeRateHistoricalData = getEthExchangeRateHistoricalData(historicalId);
+    let roundedTimestamp = (event.block.timestamp.toI32() / 3600) * 3600;
+
+    let notional = Notional.bind(event.address);
+    let rateResult = notional.getCurrencyAndRates(event.params.currencyId);
+    let ethRate = rateResult.value2;
+
+    ethExchangeRateHistoricalData.timestamp = roundedTimestamp;
+    ethExchangeRateHistoricalData.value = ethRate.rate.div(BigInt.fromI32(10).pow(10));
+    ethExchangeRateHistoricalData.ethExchangeRate = ethExchangeRate.id;
+
+    log.debug('Updated ethExchangeRateHistoricalData variables for entity {}', [ethExchangeRateHistoricalData.id]);
+    ethExchangeRateHistoricalData.save();
+}
+
+export function updateAssetExchangeRateHistoricalData(assetExchangeRate: AssetExchangeRate, event: UpdateAssetRate): void {
+    let historicalId = createHourlyId(event.params.currencyId, event.block.timestamp.toI32());
+    let assetExchangeRateHistoricalData = getAssetExchangeRateHistoricalData(historicalId);
+    let roundedTimestamp = (event.block.timestamp.toI32() / 3600) * 3600;
+
+    let notional = Notional.bind(event.address);
+    let rateResult = notional.getCurrencyAndRates(event.params.currencyId);
+    let assetRate = rateResult.value3;
+
+    assetExchangeRateHistoricalData.timestamp = roundedTimestamp;
+    assetExchangeRateHistoricalData.value = assetRate.rate.div(BigInt.fromI32(10).pow(10));
+    assetExchangeRateHistoricalData.assetExchangeRate = assetExchangeRate.id;
+
+    log.debug('Updated assetExchangeRateHistoricalData variables for entity {}', [assetExchangeRateHistoricalData.id]);
+    assetExchangeRateHistoricalData.save();
+}

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -82,6 +82,8 @@ dataSources:
           file: ./abi/Notional.json
         - name: ERC20
           file: ./abi/ERC20.json
+      blockHandlers:
+        - handler: handleBlockUpdates
       eventHandlers:
         # Governance Events
         - event: ListCurrency(uint16)


### PR DESCRIPTION
- Add ethRate and assetRate historical values
  - Values are hooked to the existing rates updates instead of using a block handler
  - A reference is kept to the rate object to grab the currency and decimal places
  - Values are kept hourly to keep it lean
- Extract exchange rate objects to new file